### PR TITLE
feat: update napalm agent dependencies and add overflow integer check

### DIFF
--- a/diode-napalm-agent/README.md
+++ b/diode-napalm-agent/README.md
@@ -9,11 +9,11 @@ This is a basic set of instructions to get started using Diode NAPALM agent on a
 ## Requirements
 
 The Diode NAPALM Agent requires a Python runtime environment and has the following requirements:
-- importlib-metadata==8.5.0
-- napalm==5.0.0
-- netboxlabs-diode-sdk==0.4.0
-- pydantic==2.9.2
-- python-dotenv==1.0.1
+- importlib-metadata~=8.5
+- napalm~=5.0
+- netboxlabs-diode-sdk~=0.4
+- pydantic~=2.9
+- python-dotenv~=1.0
 
 Instructions on installing the Diode SDK Python can be found [here](https://github.com/netboxlabs/diode-sdk-python).
 

--- a/diode-napalm-agent/diode_napalm/translate.py
+++ b/diode-napalm-agent/diode_napalm/translate.py
@@ -22,7 +22,7 @@ def int32_overflows(number: int) -> bool:
 
     Args:
     ----
-        n (int): The integer to check.
+        number (int): The integer to check.
 
     Returns:
     -------

--- a/diode-napalm-agent/pyproject.toml
+++ b/diode-napalm-agent/pyproject.toml
@@ -25,11 +25,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "importlib-metadata==8.5.0",
-    "napalm==5.0.0",
-    "netboxlabs-diode-sdk==0.4.0",
-    "pydantic==2.9.2",
-    "python-dotenv==1.0.1",
+    "importlib-metadata~=8.5",
+    "napalm~=5.0",
+    "netboxlabs-diode-sdk~=0.4",
+    "pydantic~=2.9",
+    "python-dotenv~=1.0",
 ]
 
 [project.optional-dependencies]

--- a/diode-napalm-agent/tests/test_translate.py
+++ b/diode-napalm-agent/tests/test_translate.py
@@ -41,6 +41,20 @@ def sample_interface_info():
 
 
 @pytest.fixture
+def sample_interface_overflows_info():
+    """Sample interface information for testing."""
+    return {
+        "GigabitEthernet0/0": {
+            "is_enabled": True,
+            "mtu": 150000000000,
+            "mac_address": "00:1C:58:29:4A:71",
+            "speed": 10000000000,
+            "description": "Uplink Interface",
+        }
+    }
+
+
+@pytest.fixture
 def sample_interfaces_ip():
     """Sample interface IPs for testing."""
     return {"GigabitEthernet0/0": {"ipv4": {"192.0.2.1": {"prefix_length": 24}}}}
@@ -67,7 +81,26 @@ def test_translate_interface(sample_device_info, sample_interface_info):
     assert interface.enabled is True
     assert interface.mtu == 1500
     assert interface.mac_address == "00:1C:58:29:4A:71"
-    assert interface.speed == 1000
+    assert interface.speed == 1000000
+    assert interface.description == "Uplink Interface"
+
+
+def test_translate_interface_with_overflow_data(
+    sample_device_info, sample_interface_overflows_info
+):
+    """Ensure interface translation is correct."""
+    device = translate_device(sample_device_info)
+    interface = translate_interface(
+        device,
+        "GigabitEthernet0/0",
+        sample_interface_overflows_info["GigabitEthernet0/0"],
+    )
+    assert interface.device.name == "router1"
+    assert interface.name == "GigabitEthernet0/0"
+    assert interface.enabled is True
+    assert interface.mtu == 0
+    assert interface.mac_address == "00:1C:58:29:4A:71"
+    assert interface.speed == 0
     assert interface.description == "Uplink Interface"
 
 


### PR DESCRIPTION
This PR addresses: https://github.com/netboxlabs/diode/issues/187

- Allow dependencies change for minor patches avoiding major
- Proper convert napalm interface speed (MBps) to diode/netbox expected speed (Kbps)
- Add overflow check and ignore it if it happens